### PR TITLE
ci: compile Java in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,12 @@ commands:
           name: Pull Submodules
           command: git submodule update --init
       - restore_cache:
-          name: Restoring Cache: npm cache
+          name: "Restoring Cache: npm cache"
           keys:
             - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
             - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-master-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
       - restore_cache:
-          name: Restoring Cache: gradle wrapper
+          name: "Restoring Cache: gradle wrapper"
           keys:
             - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
       - run:
@@ -30,14 +30,14 @@ commands:
           command: npm test
       - save-npm-cache
       - save_cache:
-          name: Restoring Cache: gradle wrapper
+          name: "Restoring Cache: gradle wrapper"
           paths:
             - ~/.gradle/wrapper/
           key: v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
   save-npm-cache:
     steps:
       - save_cache:
-          name: Saving Cache: npm cache
+          name: "Saving Cache: npm cache"
           key: v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
           paths:
             - ~/.npm/_cacache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ commands:
           name: Versions
           command: npm version
       - checkout
+      - run:
+          name: "Pull Submodules"
+          command: git submodule update --init
       - restore_cache:
           keys:
             - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
@@ -21,32 +24,6 @@ commands:
           name: Test
           command: npm test
       - save-npm-cache
-  test-nodejs-v6:
-    steps:
-      - run:
-          name: Versions
-          command: npm version
-      - checkout
-      - restore_cache:
-          keys:
-            - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-lock-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
-            - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-lock-master-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
-            - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
-            - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-master-{{ .Environment.CIRCLE_JOB }}
-      - run:
-          name: Install dependencies
-          command: npm install
-      - run:
-          name: Test
-          command: npm test
-      - save-npm-lock
-      - save-npm-cache
-  save-npm-lock:
-    steps:
-      - save_cache:
-          key: v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-lock-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
-          paths:
-            - node_modules
   save-npm-cache:
     steps:
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,15 @@ commands:
           command: npm version
       - checkout
       - run:
-          name: "Pull Submodules"
+          name: Pull Submodules
           command: git submodule update --init
       - restore_cache:
+          name: Restoring Cache: npm cache
           keys:
             - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
             - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-master-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
       - restore_cache:
+          name: Restoring Cache: gradle wrapper
           keys:
             - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
       - run:
@@ -28,12 +30,14 @@ commands:
           command: npm test
       - save-npm-cache
       - save_cache:
+          name: Restoring Cache: gradle wrapper
           paths:
             - ~/.gradle/wrapper/
           key: v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
   save-npm-cache:
     steps:
       - save_cache:
+          name: Saving Cache: npm cache
           key: v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
           paths:
             - ~/.npm/_cacache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ commands:
           name: Install dependencies
           command: npm ci
       - run:
+          name: Compile
+          command: npm run build
+      - run:
           name: Test
           command: npm test
       - save-npm-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,17 +54,17 @@ commands:
 jobs:
   node-v8:
     docker:
-      - image: node:8
+      - image: circleci/node:8-browsers
     steps:
       - test-nodejs
   node-v10:
     docker:
-      - image: node:10
+      - image: circleci/node:10-browsers
     steps:
       - test-nodejs
   node-v11:
     docker:
-      - image: node:11
+      - image: circleci/node:11-browsers
     steps:
       - test-nodejs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,11 @@ commands:
           command: git submodule update --init
       - restore_cache:
           keys:
-            - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
-            - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-master-{{ .Environment.CIRCLE_JOB }}
+            - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
+            - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-npm-cache-master-{{ .Environment.CIRCLE_JOB }}-{{ checksum "package-lock.json" }}
+      - restore_cache:
+          keys:
+            - v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
       - run:
           name: Install dependencies
           command: npm ci
@@ -24,6 +27,10 @@ commands:
           name: Test
           command: npm test
       - save-npm-cache
+      - save_cache:
+          paths:
+            - ~/.gradle/wrapper/
+          key: v{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ arch }}-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
   save-npm-cache:
     steps:
       - save_cache:


### PR DESCRIPTION
- use `circleci/node:X-browsers` as Docker image since it has Java8
  - https://circleci.com/docs/2.0/circleci-images/
- cache gradle wrapper
  - https://discuss.circleci.com/t/recommended-dependencies-caching-for-a-gradle-setup-is-wrong/20712/3
  - https://medium.com/@chrisbanes/circleci-cache-key-over-many-files-c9e07f4d471a